### PR TITLE
feat: implement support for automatically add ignorePaths in generated ska-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ ignorePaths:
 - .git
 - .idea
 
+# list of path (can be templated) that will be pre-populated in the final ska-config 
+skaConfig:
+  ignorePaths:
+  - "idea/*"
+  - test-file-to-be-ignored-{{.testFileName}}.txt
+  - "*.ignored"
+
 # this is the section that SKA will consume to generate the input form.
 # each input supports the following information:
 # 

--- a/internal/configuration/localconfigservice.go
+++ b/internal/configuration/localconfigservice.go
@@ -78,8 +78,20 @@ func (cs *LocalConfigService) WithExcludeMatchingFiles(ignorePaths []string) *Lo
 	return cs
 }
 
-func (cs *LocalConfigService) GetIgnorePaths() []string {
+func (cs *LocalConfigService) IgnorePaths() []string {
 	return cs.app.Config.IgnorePaths
+}
+
+func (cs *LocalConfigService) WithIgnorePaths(ignorePaths []string) *LocalConfigService {
+	cs.app.Config.IgnorePaths = ignorePaths
+	return cs
+}
+
+func (cs *LocalConfigService) WithExtendIgnorePaths(ignorePaths []string) *LocalConfigService {
+	newPaths := append(cs.app.Config.IgnorePaths, ignorePaths...)
+	slices.Sort(newPaths)
+	cs.app.Config.IgnorePaths = slices.Compact(newPaths)
+	return cs
 }
 
 func (cs *LocalConfigService) WithVariables(variables map[string]interface{}) *LocalConfigService {

--- a/internal/configuration/localconfigservice.go
+++ b/internal/configuration/localconfigservice.go
@@ -88,7 +88,7 @@ func (cs *LocalConfigService) WithIgnorePaths(ignorePaths []string) *LocalConfig
 }
 
 func (cs *LocalConfigService) WithExtendIgnorePaths(ignorePaths []string) *LocalConfigService {
-	newPaths := append(cs.app.Config.IgnorePaths, ignorePaths...)
+	newPaths := append(cs.app.Config.IgnorePaths, ignorePaths...) //nolint:gocritic
 	slices.Sort(newPaths)
 	cs.app.Config.IgnorePaths = slices.Compact(newPaths)
 	return cs

--- a/internal/configuration/upstreamconfigservice.go
+++ b/internal/configuration/upstreamconfigservice.go
@@ -23,9 +23,14 @@ type UpstreamConfigInput struct {
 	Default     string `yaml:"default,omitempty"`
 }
 
+type SkaConfig struct {
+	IgnorePaths []string `yaml:"ignorePaths"`
+}
+
 type config struct {
 	IgnorePaths []string              `yaml:"ignorePaths"`
 	Inputs      []UpstreamConfigInput `yaml:"inputs,omitempty"`
+	SkaConfig   SkaConfig             `yaml:"skaConfig,omitempty"`
 }
 
 func NewUpstreamConfigService() *UpstreamConfigService {
@@ -55,8 +60,12 @@ func (ucs *UpstreamConfigService) LoadFromPath(path string) (*UpstreamConfigServ
 	return ucs, nil
 }
 
-func (ucs *UpstreamConfigService) GetIgnorePaths() []string {
+func (ucs *UpstreamConfigService) UpstreamIgnorePaths() []string {
 	return ucs.config.IgnorePaths
+}
+
+func (ucs *UpstreamConfigService) SkaConfigIgnorePaths() []string {
+	return ucs.config.SkaConfig.IgnorePaths
 }
 
 func (ucs *UpstreamConfigService) GetInputs() []UpstreamConfigInput {

--- a/internal/filetreeprocessor/filetreeprocessor.go
+++ b/internal/filetreeprocessor/filetreeprocessor.go
@@ -1,4 +1,4 @@
-package processor
+package filetreeprocessor
 
 import (
 	"github.com/apex/log"

--- a/internal/filetreeprocessor/internal.go
+++ b/internal/filetreeprocessor/internal.go
@@ -107,20 +107,20 @@ func (tp *FileTreeProcessor) loadMultiparts() error {
 
 		// if it's file we copy the file to the destination
 		if !info.IsDir() {
-			multipart, err := multipart.NewMultipartFromFile(absPath, relPath)
+			m, err := multipart.NewMultipartFromFile(absPath, relPath)
 			if err != nil {
 				return err
 			}
 
-			if err = multipart.ParseParts(); err != nil { //nolint:gocritic
+			if err = m.ParseParts(); err != nil { //nolint:gocritic
 				return err
 			}
-			files, err := multipart.PartsToFiles()
+			files, err := m.PartsToFiles()
 			if err != nil {
 				return err
 			}
 			logger.WithFields(log.Fields{"parts": files, "multipart": relPath}).Debug("generating Parts from Multipart.")
-			tp.multiparts = append(tp.multiparts, multipart)
+			tp.multiparts = append(tp.multiparts, m)
 		} else {
 			logger.WithFields(log.Fields{"filePath": relPath}).Debug("skipping because is a directory.")
 		}

--- a/internal/filetreeprocessor/internal.go
+++ b/internal/filetreeprocessor/internal.go
@@ -1,4 +1,4 @@
-package processor
+package filetreeprocessor
 
 import (
 	"bytes"

--- a/internal/filetreeprocessor/type.go
+++ b/internal/filetreeprocessor/type.go
@@ -1,4 +1,4 @@
-package processor
+package filetreeprocessor
 
 import (
 	"github.com/apex/log"

--- a/internal/stringprocessor/stringprocessor.go
+++ b/internal/stringprocessor/stringprocessor.go
@@ -1,0 +1,59 @@
+package stringprocessor
+
+import (
+	"bytes"
+	"github.com/apex/log"
+	"github.com/gchiesa/ska/internal/templateprovider"
+)
+
+func NewStringProcessor(options ...func(stringProcessor *StringProcessor)) *StringProcessor {
+	logCtx := log.WithFields(log.Fields{
+		"pkg": "string-processor",
+	})
+
+	sp := &StringProcessor{
+		template: nil,
+		log:      logCtx,
+	}
+	// configure options
+	for _, opt := range options {
+		opt(sp)
+	}
+	return sp
+}
+
+func WithTemplateService(ts templateprovider.TemplateService) func(sp *StringProcessor) {
+	return func(sp *StringProcessor) {
+		sp.template = ts
+	}
+}
+
+func (sp *StringProcessor) Render(text string, withVariables map[string]interface{}) (string, error) {
+	logger := sp.log.WithFields(log.Fields{"method": "Render"})
+
+	if err := sp.template.FromString(text); err != nil {
+		return "", err
+	}
+
+	// render the template
+	buff := bytes.NewBufferString("")
+	if err := sp.template.Execute(buff, withVariables); err != nil {
+		if sp.template.IsMissingKeyError(err) {
+			logger.WithFields(log.Fields{"error": err.Error()}).Errorf("missing variable while rendering string: %v", err)
+		}
+		return "", err
+	}
+	return buff.String(), nil
+}
+
+func (sp *StringProcessor) RenderSliceOfStrings(text []string, variables map[string]interface{}) ([]string, error) {
+	var result []string
+	for _, entry := range text {
+		renderedEntry, err := sp.Render(entry, variables)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, renderedEntry)
+	}
+	return result, nil
+}

--- a/internal/stringprocessor/type.go
+++ b/internal/stringprocessor/type.go
@@ -1,0 +1,11 @@
+package stringprocessor
+
+import (
+	"github.com/apex/log"
+	"github.com/gchiesa/ska/internal/templateprovider"
+)
+
+type StringProcessor struct {
+	template templateprovider.TemplateService
+	log      *log.Entry
+}

--- a/pkg/skaffolder/create.go
+++ b/pkg/skaffolder/create.go
@@ -117,9 +117,8 @@ func (s *SkaCreate) Create() error {
 	}
 
 	// render the ignore entries in the upstream configuration
-	var skaConfigIgnorePaths []string
 	sp := stringprocessor.NewStringProcessor(stringprocessor.WithTemplateService(templateService))
-	skaConfigIgnorePaths, err = sp.RenderSliceOfStrings(upstreamConfig.SkaConfigIgnorePaths(), vars)
+	skaConfigIgnorePaths, err := sp.RenderSliceOfStrings(upstreamConfig.SkaConfigIgnorePaths(), vars)
 	if err != nil {
 		return err
 	}

--- a/pkg/skaffolder/update.go
+++ b/pkg/skaffolder/update.go
@@ -115,16 +115,14 @@ func (s *SkaUpdate) Update() error {
 	}
 
 	// render the ignore entries in the upstream configuration
-	var skaConfigIgnorePaths []string
 	sp := stringprocessor.NewStringProcessor(stringprocessor.WithTemplateService(templateService))
-	skaConfigIgnorePaths, err = sp.RenderSliceOfStrings(upstreamConfig.SkaConfigIgnorePaths(), vars)
+	skaConfigIgnorePaths, err := sp.RenderSliceOfStrings(upstreamConfig.SkaConfigIgnorePaths(), vars)
 	if err != nil {
 		return err
 	}
 
 	// save the config
-	err = localConfig.
-		WithVariables(vars).
+	err = localConfig.WithVariables(vars).
 		WithBlueprintUpstream(blueprintProvider.RemoteURI()).
 		WithExtendIgnorePaths(localConfig.IgnorePaths()).
 		WithExtendIgnorePaths(skaConfigIgnorePaths).


### PR DESCRIPTION
## 🎯 What

As per #62 this PR introduce the support for pre-populating the final `ska-config` named configuration with a list of ignorePaths based on the `ska-upstream.yaml` recipe.

## 🤔 Why
Please refer to issue #62 

## 📚 References
closes #62 
