### PR TITLE
feat: add new yaml-merge engine for deep YAML merging instead text base replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ The following links are examples of how you can use SKA in various common use ca
 
 * [manage multiple ska templates in the same folder](docs-md/use-case-manage-multiple-templates-same-folder.md)
 
+* [YAML-aware updates with the yaml-merge engine](docs-md/use-case-yaml-merge-engine.md)
+
 ## Integrate SKA in your project
 
 SKA is designed for simplicity and quick usage. If you want to integrate SKA capabilities in your app or framework,
@@ -213,6 +215,42 @@ rest of the file as it is.
 This is quite useful for files where only a part should be centrally managed and the rest will be customized by the
 user, after the initial creation.
 
+### Partial section engines
+
+By default, when SKA renders a managed block into the destination file it performs a **text-based replacement** — the
+entire block content is overwritten verbatim with the rendered template output.
+
+For **YAML files** SKA also supports a `yaml-merge` engine that applies a structural, key-aware merge instead of a
+wholesale text replace:
+
+- Keys present in the upstream template override the corresponding values in the destination.
+- Keys added by the developer (not present in the template) are **preserved** across updates.
+- Comments already in the destination file survive.
+
+To activate the engine, add the bracket modifier `[engine:yaml-merge]` to the `ska-start` tag in your **blueprint**
+template:
+
+```yaml
+# ska-start[engine:yaml-merge]:observability
+observability:
+  tracing:
+    enabled: true
+    samplingRate: "{{.tracingSamplingRate}}"
+# ska-end
+```
+
+> [!NOTE]
+> The `[engine:yaml-merge]` modifier belongs only in the **blueprint** template. The destination file always uses
+> the plain `# ska-start:<id>` / `# ska-end` syntax — SKA writes it that way automatically.
+
+> [!TIP]
+> On the **first** time a managed block is created in a destination file the yaml-merge engine behaves identically to
+> the default text engine (there is nothing to merge yet). The merge semantics kick in from the **second** update
+> onwards, when an existing block is already present.
+
+For a complete worked example — including how to adopt an existing, previously-unmanaged YAML file into
+ska-managed yaml-merge blocks — see
+[USE CASE: YAML Merge Engine](docs-md/use-case-yaml-merge-engine.md).
 
 ### Template variable collection via Terminal UI
 

--- a/docs-md/use-case-yaml-merge-engine.md
+++ b/docs-md/use-case-yaml-merge-engine.md
@@ -1,0 +1,339 @@
+# USE CASE: YAML-Aware Updates with the `yaml-merge` Engine
+
+This guide shows how to:
+
+- Keep only specific keys of a YAML file centrally managed while letting developers freely extend the rest.
+- Prevent upstream updates from wiping out keys that are not known to the blueprint.
+- Adopt an existing, previously-unmanaged YAML file into SKA using a one-shot replacement directive, after which every
+  subsequent update uses the YAML merge engine.
+
+## Why the default text engine is not always enough
+
+The default SKA engine replaces the content of a managed block verbatim on every update. That is exactly what you want
+for most files — markup, scripts, Dockerfiles — where the template owns the whole block.
+
+For YAML configuration files the story is different: teams often need to add service-specific keys *inside* a section
+that is partially governed by a central platform team. With a text-based replacement those additions disappear on the
+next `ska update`.
+
+The `yaml-merge` engine solves this: it computes a **structural diff** between the upstream template and the current
+destination block, then applies only the keys that are present in the template. Keys that exist only in the destination
+are left untouched.
+
+## How it works
+
+Add the `[engine:yaml-merge]` bracket modifier to the `ska-start` tag in your **blueprint** template:
+
+```yaml
+# ska-start[engine:yaml-merge]:platform-settings
+platform:
+  logging:
+    level: "{{.logLevel}}"
+    format: json
+  tracing:
+    enabled: true
+    samplingRate: "{{.tracingSamplingRate}}"
+# ska-end
+```
+
+> [!NOTE]
+> The modifier is only meaningful in the **blueprint**. SKA writes a plain `# ska-start:<id>` / `# ska-end` block
+> into the destination — no modifier is stored there.
+
+When `ska update` runs:
+
+1. The upstream template is rendered with the captured variables.
+2. If a `# ska-start:platform-settings` block already exists in the destination, SKA merges the rendered output
+   **into** the existing block instead of replacing it wholesale.
+3. Keys in the rendered template override the corresponding destination values.
+4. Keys present only in the destination are preserved unchanged.
+5. SKA logs every key path it patched at `DEBUG` level, e.g.:
+   ```
+   DEBUG  [engine:yaml-merge]  [patch]  [platform.tracing.samplingRate]
+   ```
+
+> [!TIP]
+> On the **first** scaffolding (no block exists yet) the yaml-merge engine behaves like the default engine — the
+> block is created wholesale. Merge semantics apply from the **second** `ska update` onward.
+
+---
+
+## Scenario: service runtime configuration
+
+### Blueprint layout
+
+```
+templates-repo/
+  service-runtime/
+    .ska-upstream.yaml
+    app-config.yaml       ← centrally managed YAML template
+    main.go
+    ...
+```
+
+### `app-config.yaml` in the blueprint
+
+The platform team owns the `platform` section. Everything else can be freely extended by the service team.
+
+```yaml
+# Managed by the platform team — do not edit the platform section by hand.
+# ska-start[engine:yaml-merge]:platform-settings
+platform:
+  logging:
+    level: "{{.logLevel}}"
+    format: json
+  tracing:
+    enabled: true
+    samplingRate: "{{.tracingSamplingRate}}"
+  security:
+    tlsMinVersion: "{{.tlsMinVersion}}"
+# ska-end
+
+# Service-team section — add your own keys freely below this line.
+service: { }
+```
+
+### After initial scaffolding
+
+`ska create` expands the template. The destination `app-config.yaml` in the project looks like this (variables replaced,
+markers written without engine modifier):
+
+```yaml
+# Managed by the platform team — do not edit the platform section by hand.
+# ska-start:platform-settings
+platform:
+  logging:
+    level: info
+    format: json
+  tracing:
+    enabled: true
+    samplingRate: "0.05"
+  security:
+    tlsMinVersion: "TLSv1.2"
+# ska-end
+
+# Service-team section — add your own keys freely below this line.
+service: { }
+```
+
+### Developer adds service-specific settings
+
+The team extends the file with their own keys — both inside and outside the managed block:
+
+```yaml
+# Managed by the platform team — do not edit the platform section by hand.
+# ska-start:platform-settings
+platform:
+  logging:
+    level: info
+    format: json
+  tracing:
+    enabled: true
+    samplingRate: "0.05"
+  security:
+    tlsMinVersion: "TLSv1.2"
+  # team added: custom exporter endpoint
+  metrics:
+    exporterURL: "https://metrics.internal/push"
+# ska-end
+
+# Service-team section — add your own keys freely below this line.
+service:
+  name: payment-processor
+  port: 8080
+  db:
+    host: postgres.internal
+    maxConns: 20
+```
+
+### Platform team releases a new template version
+
+The blueprint is updated: `tracingSamplingRate` bumped to `0.1` and a new key `security.mTLS` is added. The service team
+runs:
+
+```sh
+ska update --path .
+```
+
+**Result** — only the keys managed by the upstream template are touched:
+
+```yaml
+# Managed by the platform team — do not edit the platform section by hand.
+# ska-start:platform-settings
+platform:
+  logging:
+    level: info
+    format: json
+  tracing:
+    enabled: true
+    samplingRate: "0.1"       # ← updated from upstream
+  security:
+    tlsMinVersion: "TLSv1.2"
+    mTLS: true                # ← new key from upstream
+  # team added: custom exporter endpoint
+  metrics:
+    exporterURL: "https://metrics.internal/push"   # ← preserved
+# ska-end
+
+# Service-team section — add your own keys freely below this line.
+service:
+  name: payment-processor
+  port: 8080
+  db:
+    host: postgres.internal
+    maxConns: 20
+```
+
+`metrics.exporterURL` — added by the team inside the managed block — survives the update because the yaml-merge engine
+does not know about it and therefore does not touch it.
+
+---
+
+## Scenario: adopting an existing YAML file
+
+Sometimes a project already has a YAML configuration file that was written by hand before SKA was introduced. The file
+has no `ska-start` / `ska-end` markers, so SKA does not touch it during normal updates.
+
+The solution is a **one-shot adoption** using the `ska-replace-match` directive in combination with the
+`yaml-merge` engine modifier. On the first run, `ska-replace-match` replaces the **entire file content** with a freshly
+rendered managed block. From that point on, the block is present and every subsequent update uses the
+`yaml-merge` engine — incremental and non-destructive.
+
+> [!WARNING]
+> `ska-replace-match` with a whole-file regex is **destructive on first use**: it discards the original
+> hand-crafted content and replaces it with the template output. Back up anything you need to keep before
+> running the adoption update, then re-add it manually inside (or outside) the managed block afterwards.
+
+### The existing file (in the project, not managed by SKA)
+
+```yaml
+# app-config.yaml — hand-crafted, no SKA markers yet
+platform:
+  logging:
+    level: warn
+  tracing:
+    enabled: false
+  security:
+    tlsMinVersion: "TLSv1.1"
+```
+
+### Blueprint template that adopts the file
+
+Add the `ska-replace-match` directive with the regex `(?s).*` — the `(?s)` flag makes `.` match newlines, so
+`.*` greedily matches the entire file content and replaces it with the managed block.
+
+```yaml
+# ska-start[engine:yaml-merge]:platform-settings + ska-replace-match:(?s).*
+platform:
+  logging:
+    level: "{{.logLevel}}"
+    format: json
+  tracing:
+    enabled: true
+    samplingRate: "{{.tracingSamplingRate}}"
+  security:
+    tlsMinVersion: "{{.tlsMinVersion}}"
+# ska-end
+```
+
+> [!NOTE]
+> `ska-replace-match` is a one-shot directive: it fires **only when no managed block with that identifier is
+> present** in the destination. Once `# ska-start:platform-settings` exists, subsequent updates use the
+> yaml-merge engine and the replace directive is silently skipped.
+
+### First `ska update` — adoption run
+
+SKA finds no `# ska-start:platform-settings` block in `app-config.yaml`. The `ska-replace-match:(?s).*`
+directive fires: `(?s).*` matches the entire file in one pass, and the whole content is replaced with the rendered
+managed block:
+
+```yaml
+# ska-start:platform-settings
+platform:
+  logging:
+    level: info
+    format: json
+  tracing:
+    enabled: true
+    samplingRate: "0.05"
+  security:
+    tlsMinVersion: "TLSv1.2"
+# ska-end
+```
+
+The original hand-crafted content is gone. The file is now clean and fully under SKA management.
+
+### Team extends the managed block after adoption
+
+After the adoption the service team adds their own keys inside the block:
+
+```yaml
+# ska-start:platform-settings
+platform:
+  logging:
+    level: info
+    format: json
+  tracing:
+    enabled: true
+    samplingRate: "0.05"
+  security:
+    tlsMinVersion: "TLSv1.2"
+  # team added after adoption
+  metrics:
+    exporterURL: "https://metrics.internal/push"
+# ska-end
+```
+
+### Every subsequent `ska update` — yaml-merge takes over
+
+From the second update on, the `# ska-start:platform-settings` block already exists. SKA applies the yaml-merge engine:
+only the keys present in the upstream template are updated; anything the team has added inside the block is preserved.
+
+For example, when the platform team bumps `samplingRate` to `0.1` and adds `security.mTLS`:
+
+```yaml
+# ska-start:platform-settings
+platform:
+  logging:
+    level: info
+    format: json
+  tracing:
+    enabled: true
+    samplingRate: "0.1"      # ← updated from upstream
+  security:
+    tlsMinVersion: "TLSv1.2"
+    mTLS: true               # ← new key from upstream
+  # team added after adoption
+  metrics:
+    exporterURL: "https://metrics.internal/push"   # ← preserved
+# ska-end
+```
+
+---
+
+## Quick reference
+
+### Tag syntax
+
+| Use case                                                           | Blueprint tag                                                        |
+|--------------------------------------------------------------------|----------------------------------------------------------------------|
+| Default text engine (entire block replaced)                        | `# ska-start:my-block`                                               |
+| YAML merge engine (structural key merge)                           | `# ska-start[engine:yaml-merge]:my-block`                            |
+| One-shot adoption: replace entire file, then yaml-merge on updates | `# ska-start[engine:yaml-merge]:my-block + ska-replace-match:(?s).*` |
+
+### Behaviour matrix
+
+| Situation                             | Default engine                     | `yaml-merge` engine |
+|---------------------------------------|------------------------------------|---------------------|
+| Block does not exist yet              | Adopt directive fires (or nothing) | Same as default     |
+| Block exists, key in template         | Value overwritten                  | Value overwritten   |
+| Block exists, key only in destination | **Key deleted**                    | **Key preserved**   |
+| Block exists, new key in template     | Key inserted                       | Key inserted        |
+| YAML comments in destination          | Lost on update                     | Preserved           |
+
+> [!TIP]
+> **When to prefer each engine**
+> - Use the **default engine** for non-YAML files, or for YAML blocks where the upstream template owns *all* keys
+    > and developers should never add extra ones.
+> - Use the **yaml-merge engine** whenever a YAML block is shared between central governance and local
+    > customisation — typical for configuration files, Helm values, Kubernetes manifests, and similar.

--- a/internal/multipart/fixtures/yaml-merge-blueprint.txt
+++ b/internal/multipart/fixtures/yaml-merge-blueprint.txt
@@ -1,0 +1,5 @@
+# ska-start[engine:yaml-merge]:yaml-section
+test:
+  key: abc
+  version: {{.newVersion}}
+# ska-end

--- a/internal/multipart/fixtures/yaml-merge-dest-before.txt
+++ b/internal/multipart/fixtures/yaml-merge-dest-before.txt
@@ -1,0 +1,8 @@
+preamble: true
+# ska-start:yaml-section
+test:
+  key: abc
+  version: base
+  extraKey: preserved
+# ska-end
+postamble: true

--- a/internal/multipart/fixtures/yaml-merge-partial-blueprint.txt
+++ b/internal/multipart/fixtures/yaml-merge-partial-blueprint.txt
@@ -1,0 +1,8 @@
+test:
+  key: 123
+  version: base
+  data:
+  # ska-start[engine:yaml-merge]:yaml-partial
+    test2:
+        key2: newValue
+  # ska-end

--- a/internal/multipart/fixtures/yaml-merge-partial-dest-before.txt
+++ b/internal/multipart/fixtures/yaml-merge-partial-dest-before.txt
@@ -1,0 +1,10 @@
+test:
+  key: 123
+  version: base
+  data:
+  # ska-start:yaml-partial
+    test2:
+        key2: value2
+    userAdded:
+        key3: value3
+  # ska-end

--- a/internal/multipart/multipart.go
+++ b/internal/multipart/multipart.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/apex/log"
 	"github.com/gchiesa/ska/internal/part"
+	"github.com/gchiesa/ska/internal/yamlmerge"
 )
 
 type Multipart struct {
@@ -121,8 +122,12 @@ func (mp *Multipart) CompileToFile(filePath string, forceRecompile bool) error {
 		// First check if a managed block for this section already exists (for idempotency)
 		re := buildReplaceRegexp(p.ID())
 		if re.Match(dataContent) {
-			// Replace existing managed block with updated content
-			dataContent = re.ReplaceAll(dataContent, []byte(`${1}:${2}`+"\n"+string(compiledPartial)+`${4}`))
+			if p.Engine() == yamlmerge.EngineID {
+				dataContent = mp.applyYAMLMerge(dataContent, re, compiledPartial, p.ID())
+			} else {
+				// Default text-based replacement.
+				dataContent = re.ReplaceAll(dataContent, []byte(`${1}:${2}`+"\n"+string(compiledPartial)+`${4}`))
+			}
 			continue
 		}
 		// No existing block - if a special adopt type is requested, process it
@@ -142,6 +147,52 @@ func (mp *Multipart) CompileToFile(filePath string, forceRecompile bool) error {
 	}
 	mp.contentCompiled = dataContent
 	return os.WriteFile(filePath, dataContent, 0o644) // noling:gosec
+}
+
+// applyYAMLMerge performs a YAML deep-merge of compiledPartial into the existing managed block
+// found in dataContent by re, and returns the updated dataContent.
+// If the merge fails, it falls back to a plain text replacement and logs the error.
+//
+// NOTE: buildReplaceRegexp's \s* (between the identifier and group-3) greedily consumes the newline
+// plus any leading whitespace of the first content line, which would strip the common indent and
+// produce invalid YAML for indented blocks. To avoid this we locate the content boundary manually:
+// we start just after the end of group-2 (the section identifier), skip inline whitespace only
+// (not the newline), then skip one newline. This preserves each line's original leading spaces.
+func (mp *Multipart) applyYAMLMerge(dataContent []byte, re *regexp.Regexp, compiledPartial []byte, partID string) []byte {
+	idxs := re.FindSubmatchIndex(dataContent)
+	if idxs == nil {
+		return dataContent
+	}
+
+	// Locate the start of the actual block content:
+	// idxs[4]:idxs[5] is group-2 (section identifier).
+	// Skip trailing inline whitespace (spaces/tabs) then one newline.
+	contentStart := idxs[5]
+	for contentStart < len(dataContent) && (dataContent[contentStart] == ' ' || dataContent[contentStart] == '\t') {
+		contentStart++
+	}
+	if contentStart < len(dataContent) && dataContent[contentStart] == '\n' {
+		contentStart++
+	}
+
+	// Content ends just before the ska-end line (start of group-4, idxs[8]).
+	contentEnd := idxs[8]
+
+	existingContent := dataContent[contentStart:contentEnd]
+	mergedContent, changedPaths, err := yamlmerge.MergeYAML(existingContent, compiledPartial)
+	if err != nil {
+		mp.log.WithFields(log.Fields{"partID": partID, "engine": "yaml-merge"}).
+			Errorf("yaml merge failed, falling back to text replacement: %v", err)
+		return re.ReplaceAll(dataContent, []byte(`${1}:${2}`+"\n"+string(compiledPartial)+`${4}`))
+	}
+	for _, path := range changedPaths {
+		mp.log.WithFields(log.Fields{"engine": "yaml-merge", "patch": path}).Debug("applying patch")
+	}
+	result := make([]byte, 0, len(dataContent)-len(existingContent)+len(mergedContent))
+	result = append(result, dataContent[:contentStart]...)
+	result = append(result, mergedContent...)
+	result = append(result, dataContent[contentEnd:]...)
+	return result
 }
 
 // buildManagedBlock creates a canonical managed block without directive in the header for idempotency

--- a/internal/multipart/multipart_test.go
+++ b/internal/multipart/multipart_test.go
@@ -255,6 +255,105 @@ func TestAdoptReplaceMatchWholeAndGroup(t *testing.T) {
 	}
 }
 
+func TestYAMLMergeEngine_fullBlock(t *testing.T) {
+	t.Parallel()
+	// Blueprint has [engine:yaml-merge] modifier; compiled partial replaces test.version but
+	// the destination's extra key (extraKey) should be preserved.
+	tmp := t.TempDir()
+
+	bpContent, err := os.ReadFile(filepath.Join("fixtures", "yaml-merge-blueprint.txt"))
+	if err != nil {
+		t.Fatalf("read blueprint: %v", err)
+	}
+	beforeContent, err := os.ReadFile(filepath.Join("fixtures", "yaml-merge-dest-before.txt"))
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+
+	bpPath := writeTempFile(t, tmp, "blue.yaml", string(bpContent))
+	m, err := NewMultipartFromFile(bpPath, "blue.yaml")
+	if err != nil {
+		t.Fatalf("multipart: %v", err)
+	}
+	if err := m.ParseParts(); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	require := assert.New(t) // use assert as require for brevity
+	require.Equal(1, len(m.Parts()))
+	require.Equal("yaml-merge", m.Parts()[0].Engine())
+
+	// Write compiled partial: the rendered template output (test.version = v2.0).
+	partialContent := "test:\n  key: abc\n  version: v2.0\n"
+	for _, p := range m.Parts() {
+		writeTempFile(t, filepath.Dir(bpPath), p.RefFileBasename(), partialContent)
+	}
+
+	dest := writeTempFile(t, tmp, "dest.yaml", string(beforeContent))
+	if err := m.CompileToFile(dest, false); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	data, _ := os.ReadFile(dest)
+	got := string(data)
+
+	// version should be updated
+	assert.Contains(t, got, "version: v2.0")
+	// extra key added by user should be preserved
+	assert.Contains(t, got, "extraKey: preserved")
+	// preamble and postamble survive
+	assert.Contains(t, got, "preamble: true")
+	assert.Contains(t, got, "postamble: true")
+}
+
+func TestYAMLMergeEngine_partialSection(t *testing.T) {
+	t.Parallel()
+	// Blueprint has a partial section with yaml-merge engine.
+	// Destination has userAdded key that must survive the merge.
+	tmp := t.TempDir()
+
+	bpContent, err := os.ReadFile(filepath.Join("fixtures", "yaml-merge-partial-blueprint.txt"))
+	if err != nil {
+		t.Fatalf("read blueprint: %v", err)
+	}
+	beforeContent, err := os.ReadFile(filepath.Join("fixtures", "yaml-merge-partial-dest-before.txt"))
+	if err != nil {
+		t.Fatalf("read before: %v", err)
+	}
+
+	bpPath := writeTempFile(t, tmp, "blue.yaml", string(bpContent))
+	m, err := NewMultipartFromFile(bpPath, "blue.yaml")
+	if err != nil {
+		t.Fatalf("multipart: %v", err)
+	}
+	if err := m.ParseParts(); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	assert.Equal(t, 1, len(m.Parts()))
+	assert.Equal(t, "yaml-merge", m.Parts()[0].Engine())
+
+	// Write compiled partial (rendered template): test2.key2 updated to "rendered".
+	partialContent := "    test2:\n        key2: rendered\n"
+	for _, p := range m.Parts() {
+		writeTempFile(t, filepath.Dir(bpPath), p.RefFileBasename(), partialContent)
+	}
+
+	dest := writeTempFile(t, tmp, "dest.yaml", string(beforeContent))
+	if err := m.CompileToFile(dest, false); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	data, _ := os.ReadFile(dest)
+	got := string(data)
+
+	// key2 should be updated
+	assert.Contains(t, got, "key2: rendered")
+	// userAdded key must be preserved
+	assert.Contains(t, got, "userAdded")
+	assert.Contains(t, got, "key3: value3")
+	// surrounding YAML structure preserved
+	assert.Contains(t, got, "version: base")
+}
+
 func TestReplaceMatchMultiline(t *testing.T) {
 	// Test that replaceMatch correctly handles multiline content with ^ and $ anchors
 	base := []byte(`FROM alpine:3.20

--- a/internal/part/part.go
+++ b/internal/part/part.go
@@ -16,6 +16,7 @@ type Part struct {
 	id               string
 	adoptType        string // e.g. replace-match, inject-before, inject-after
 	adoptArg         string // e.g. @start, @end, /^.*$/
+	engine           string // e.g. "yaml-merge" or "" for the default text engine
 	content          []byte
 }
 
@@ -82,6 +83,12 @@ func (p *Part) ID() string {
 
 func (p *Part) AdoptType() string { return p.adoptType }
 func (p *Part) AdoptArg() string  { return p.adoptArg }
+func (p *Part) Engine() string    { return p.engine }
+
+func (p *Part) SetEngine(engine string) *Part {
+	p.engine = engine
+	return p
+}
 
 func (p *Part) WithContent(content []byte) *Part {
 	p.content = content
@@ -99,6 +106,7 @@ func (p *Part) CreateFile() error {
 
 // ParseParts extracts structured parts from the originalContent based on specific delimiters and directives in the headers.
 // It returns a slice of Part with metadata and content, or an error if parsing fails.
+// The regex now has 3 capture groups: modifiers (optional bracket group), header (identifier + directive), content.
 func ParseParts(originalContent []byte, parentRefFileURI string) ([]Part, error) {
 	var parts []Part
 	reSection := getPartialsRegexp()
@@ -106,8 +114,9 @@ func ParseParts(originalContent []byte, parentRefFileURI string) ([]Part, error)
 	matches := reSection.FindAllSubmatch(originalContent, -1)
 
 	for _, match := range matches {
-		originalHeader := strings.TrimSpace(string(match[1]))
-		content := string(match[2])
+		modifiers := strings.TrimSpace(string(match[1]))      // optional: e.g. "engine:yaml-merge"
+		originalHeader := strings.TrimSpace(string(match[2])) // e.g. "my-section + ska-inject-before:@start"
+		content := string(match[3])
 		sectionName, adoptType, adoptArg, err := parseHeader(originalHeader)
 		if err != nil {
 			return nil, err
@@ -116,9 +125,27 @@ func ParseParts(originalContent []byte, parentRefFileURI string) ([]Part, error)
 		if adoptType != "" {
 			partial = partial.SetAdopt(adoptType, adoptArg)
 		}
+		if engine := parseModifiersEngine(modifiers); engine != "" {
+			partial = partial.SetEngine(engine)
+		}
 		parts = append(parts, *partial)
 	}
 	return parts, nil
+}
+
+// parseModifiersEngine extracts the engine value from the bracket modifiers string.
+// The modifiers format is a comma-separated list of key:value pairs, e.g. "engine:yaml-merge".
+func parseModifiersEngine(modifiers string) string {
+	if modifiers == "" {
+		return ""
+	}
+	for _, token := range strings.Split(modifiers, ",") {
+		kv := strings.SplitN(strings.TrimSpace(token), ":", 2)
+		if len(kv) == 2 && strings.TrimSpace(kv[0]) == "engine" {
+			return strings.TrimSpace(kv[1])
+		}
+	}
+	return ""
 }
 
 // parseHeader splits the part header "<section> [+ directive:arg]" into components

--- a/internal/part/util.go
+++ b/internal/part/util.go
@@ -10,8 +10,15 @@ const DelimiterStart = "ska-start"
 const DelimiterEnd = "ska-end"
 
 // getPartialsRegexp compiles and returns a regular expression for matching patterns with specific delimiters in a text.
+// It supports an optional bracket modifier group between the start delimiter and the colon, e.g.:
+//
+//	`# ska-start[engine:yaml-merge]:identifier`  (new format with modifiers)
+//	`# ska-start:identifier`                     (legacy format without modifiers)
+//
+// Capture groups: 1=modifiers (optional), 2=header (identifier + optional directive), 3=content
 func getPartialsRegexp() *regexp.Regexp {
-	// `(?m)(?s)^\s*.{1}\s*%s:(.*?)\s*\n(.*?)^\s*.{1}\s*%s`gm
-	pattern := fmt.Sprintf(`(?m)(?s)^\s*.{1}\s*%s:(.*?)\s*\n(.*?)^\s*.{1}\s*%s`, regexp.QuoteMeta(DelimiterStart), regexp.QuoteMeta(DelimiterEnd))
+	// `(?m)(?s)^\s*.{1}\s*ska-start(?:\[(.*?)\])?:(.*?)\s*\n(.*?)^\s*.{1}\s*ska-end`
+	pattern := fmt.Sprintf(`(?m)(?s)^\s*.{1}\s*%s(?:\[(.*?)\])?:(.*?)\s*\n(.*?)^\s*.{1}\s*%s`,
+		regexp.QuoteMeta(DelimiterStart), regexp.QuoteMeta(DelimiterEnd))
 	return regexp.MustCompile(pattern)
 }

--- a/internal/yamlmerge/yamlmerge.go
+++ b/internal/yamlmerge/yamlmerge.go
@@ -1,0 +1,210 @@
+package yamlmerge
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// EngineID is the engine identifier used in ska-start bracket modifiers.
+const EngineID = "yaml-merge"
+
+// MergeYAML deep-merges src YAML content into dst YAML content.
+// Keys present in src override those in dst; keys only in dst are preserved.
+// Comments in dst are preserved where possible via yaml.v3 Node-based round-trip.
+//
+// Returns:
+//   - merged YAML bytes (with the same leading indentation as dst)
+//   - list of dot-separated key paths that were patched (for debug logging)
+//   - any error encountered
+func MergeYAML(dst, src []byte) ([]byte, []string, error) {
+	// Detect and strip common indentation so yaml.v3 can parse without ambiguity.
+	dstStripped, dstIndent := stripCommonIndent(dst)
+	srcStripped, _ := stripCommonIndent(src)
+
+	// If either side is blank, nothing to merge.
+	if len(bytes.TrimSpace(dstStripped)) == 0 || len(bytes.TrimSpace(srcStripped)) == 0 {
+		return dst, nil, nil
+	}
+
+	var dstDoc yaml.Node
+	if err := yaml.Unmarshal(dstStripped, &dstDoc); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse destination YAML: %w", err)
+	}
+
+	var srcDoc yaml.Node
+	if err := yaml.Unmarshal(srcStripped, &srcDoc); err != nil {
+		return nil, nil, fmt.Errorf("failed to parse source YAML: %w", err)
+	}
+
+	if dstDoc.Kind != yaml.DocumentNode || len(dstDoc.Content) == 0 {
+		return dst, nil, nil
+	}
+	if srcDoc.Kind != yaml.DocumentNode || len(srcDoc.Content) == 0 {
+		return dst, nil, nil
+	}
+
+	var changedPaths []string
+	mergeNodes(dstDoc.Content[0], srcDoc.Content[0], "", &changedPaths)
+
+	// Serialize the mutated dst document back to YAML.
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(dstDoc.Content[0]); err != nil {
+		return nil, nil, fmt.Errorf("failed to serialize merged YAML: %w", err)
+	}
+	_ = enc.Close()
+
+	merged := buf.Bytes()
+
+	// Re-apply the original indentation that was stripped earlier.
+	if dstIndent > 0 {
+		merged = addIndent(merged, dstIndent)
+	}
+
+	return merged, changedPaths, nil
+}
+
+// mergeNodes recursively merges src node into dst node, recording changed paths.
+func mergeNodes(dst, src *yaml.Node, keyPath string, changedPaths *[]string) {
+	if dst.Kind != src.Kind {
+		// Incompatible kinds – replace scalar/value and record the path.
+		if keyPath != "" {
+			*changedPaths = append(*changedPaths, keyPath)
+		}
+		dst.Kind = src.Kind
+		dst.Tag = src.Tag
+		dst.Value = src.Value
+		dst.Style = src.Style
+		dst.Content = src.Content
+		return
+	}
+
+	switch dst.Kind {
+	case yaml.MappingNode:
+		mergeMappingNodes(dst, src, keyPath, changedPaths)
+	case yaml.SequenceNode:
+		// Sequences are replaced wholesale.
+		if !nodesEqual(dst, src) {
+			if keyPath != "" {
+				*changedPaths = append(*changedPaths, keyPath)
+			}
+			dst.Content = src.Content
+			dst.Style = src.Style
+		}
+	case yaml.ScalarNode:
+		if dst.Value != src.Value {
+			if keyPath != "" {
+				*changedPaths = append(*changedPaths, keyPath)
+			}
+			dst.Value = src.Value
+			dst.Tag = src.Tag
+			dst.Style = src.Style
+		}
+	}
+}
+
+// mergeMappingNodes merges a src MappingNode into dst MappingNode.
+func mergeMappingNodes(dst, src *yaml.Node, keyPath string, changedPaths *[]string) {
+	// Build an index: key string -> index of the value node in dst.Content.
+	dstKeyIdx := make(map[string]int, len(dst.Content)/2)
+	for i := 0; i < len(dst.Content)-1; i += 2 {
+		dstKeyIdx[dst.Content[i].Value] = i + 1
+	}
+
+	for i := 0; i < len(src.Content)-1; i += 2 {
+		srcKey := src.Content[i]
+		srcVal := src.Content[i+1]
+
+		childPath := srcKey.Value
+		if keyPath != "" {
+			childPath = keyPath + "." + srcKey.Value
+		}
+
+		if valIdx, exists := dstKeyIdx[srcKey.Value]; exists {
+			dstVal := dst.Content[valIdx]
+			if dstVal.Kind == srcVal.Kind {
+				mergeNodes(dstVal, srcVal, childPath, changedPaths)
+			} else {
+				// Kinds differ – replace and record.
+				if !nodesEqual(dstVal, srcVal) {
+					*changedPaths = append(*changedPaths, childPath)
+				}
+				dst.Content[valIdx] = srcVal
+			}
+		} else {
+			// New key not present in dst – add it.
+			*changedPaths = append(*changedPaths, childPath)
+			dst.Content = append(dst.Content, srcKey, srcVal)
+		}
+	}
+}
+
+// nodesEqual performs a deep structural equality check on two yaml.Nodes.
+func nodesEqual(a, b *yaml.Node) bool {
+	if a.Kind != b.Kind || a.Value != b.Value {
+		return false
+	}
+	if len(a.Content) != len(b.Content) {
+		return false
+	}
+	for i := range a.Content {
+		if !nodesEqual(a.Content[i], b.Content[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// stripCommonIndent detects the minimum leading whitespace across all non-empty lines,
+// strips that many characters from the beginning of every line, and returns the result
+// together with the stripped indent width.
+func stripCommonIndent(content []byte) ([]byte, int) {
+	lines := strings.Split(string(content), "\n")
+	minIndent := -1
+
+	for _, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		n := len(line) - len(strings.TrimLeft(line, " \t"))
+		if minIndent < 0 || n < minIndent {
+			minIndent = n
+		}
+	}
+
+	if minIndent <= 0 {
+		return content, 0
+	}
+
+	stripped := make([]string, len(lines))
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			stripped[i] = ""
+		} else if len(line) >= minIndent {
+			stripped[i] = line[minIndent:]
+		} else {
+			stripped[i] = line
+		}
+	}
+
+	return []byte(strings.Join(stripped, "\n")), minIndent
+}
+
+// addIndent prepends indent spaces to each non-empty line of content.
+func addIndent(content []byte, indent int) []byte {
+	prefix := strings.Repeat(" ", indent)
+	lines := strings.Split(string(content), "\n")
+	indented := make([]string, len(lines))
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "" {
+			indented[i] = ""
+		} else {
+			indented[i] = prefix + line
+		}
+	}
+	return []byte(strings.Join(indented, "\n"))
+}

--- a/internal/yamlmerge/yamlmerge.go
+++ b/internal/yamlmerge/yamlmerge.go
@@ -182,11 +182,12 @@ func stripCommonIndent(content []byte) ([]byte, int) {
 
 	stripped := make([]string, len(lines))
 	for i, line := range lines {
-		if strings.TrimSpace(line) == "" {
+		switch {
+		case strings.TrimSpace(line) == "":
 			stripped[i] = ""
-		} else if len(line) >= minIndent {
+		case len(line) >= minIndent:
 			stripped[i] = line[minIndent:]
-		} else {
+		default:
 			stripped[i] = line
 		}
 	}

--- a/internal/yamlmerge/yamlmerge_test.go
+++ b/internal/yamlmerge/yamlmerge_test.go
@@ -1,0 +1,169 @@
+package yamlmerge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestMergeYAML_scalarOverride(t *testing.T) {
+	t.Parallel()
+	dst := []byte(`test:
+  key: abc
+  version: base
+`)
+	src := []byte(`test:
+  version: updated
+`)
+	merged, paths, err := MergeYAML(dst, src)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(merged, &result))
+
+	testMap := result["test"].(map[string]interface{})
+	assert.Equal(t, "abc", testMap["key"])         // preserved
+	assert.Equal(t, "updated", testMap["version"]) // overridden
+
+	assert.Contains(t, paths, "test.version")
+	assert.NotContains(t, paths, "test.key")
+}
+
+func TestMergeYAML_preservesExtraKeys(t *testing.T) {
+	t.Parallel()
+	dst := []byte(`test2:
+    key2: value2
+userAdded:
+    key3: value3
+`)
+	src := []byte(`test2:
+    key2: newValue
+`)
+	merged, paths, err := MergeYAML(dst, src)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(merged, &result))
+
+	test2 := result["test2"].(map[string]interface{})
+	assert.Equal(t, "newValue", test2["key2"]) // overridden
+
+	userAdded, ok := result["userAdded"]
+	assert.True(t, ok, "userAdded key should be preserved")
+	assert.Equal(t, "value3", userAdded.(map[string]interface{})["key3"])
+
+	assert.Contains(t, paths, "test2.key2")
+}
+
+func TestMergeYAML_withLeadingIndent(t *testing.T) {
+	t.Parallel()
+	// Simulates content extracted from inside a managed block (4-space common indent)
+	dst := []byte("    test2:\n        key2: value2\n    userAdded:\n        key3: value3\n")
+	src := []byte("    test2:\n        key2: rendered\n")
+
+	merged, paths, err := MergeYAML(dst, src)
+	require.NoError(t, err)
+
+	// The merged content should still have the same indentation level.
+	assert.Contains(t, string(merged), "    ")
+	assert.Contains(t, paths, "test2.key2")
+
+	// Parse after stripping indent to verify correctness.
+	stripped, _ := stripCommonIndent(merged)
+	var result map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(stripped, &result))
+
+	assert.Equal(t, "rendered", result["test2"].(map[string]interface{})["key2"])
+	assert.Equal(t, "value3", result["userAdded"].(map[string]interface{})["key3"])
+}
+
+func TestMergeYAML_noChanges(t *testing.T) {
+	t.Parallel()
+	dst := []byte(`key: value
+`)
+	src := []byte(`key: value
+`)
+	_, paths, err := MergeYAML(dst, src)
+	require.NoError(t, err)
+	assert.Empty(t, paths)
+}
+
+func TestMergeYAML_emptySrc(t *testing.T) {
+	t.Parallel()
+	dst := []byte(`key: value
+`)
+	merged, paths, err := MergeYAML(dst, []byte("   \n"))
+	require.NoError(t, err)
+	assert.Equal(t, dst, merged)
+	assert.Empty(t, paths)
+}
+
+func TestMergeYAML_addNewKey(t *testing.T) {
+	t.Parallel()
+	dst := []byte(`existing: yes
+`)
+	src := []byte(`newKey: added
+`)
+	merged, paths, err := MergeYAML(dst, src)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(merged, &result))
+	assert.Equal(t, "yes", result["existing"])
+	assert.Equal(t, "added", result["newKey"])
+	assert.Contains(t, paths, "newKey")
+}
+
+func TestStripCommonIndent(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name           string
+		input          string
+		expectedIndent int
+		expectedLine0  string
+	}{
+		{"no indent", "key: val\n", 0, "key: val"},
+		{"2-space indent", "  key: val\n  other: x\n", 2, "key: val"},
+		{"4-space indent", "    key: val\n    other: x\n", 4, "key: val"},
+		{"mixed: preserves relative", "    a: 1\n      b: 2\n", 4, "a: 1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stripped, indent := stripCommonIndent([]byte(tc.input))
+			assert.Equal(t, tc.expectedIndent, indent)
+			lines := splitLines(string(stripped))
+			if len(lines) > 0 {
+				assert.Equal(t, tc.expectedLine0, lines[0])
+			}
+		})
+	}
+}
+
+func splitLines(s string) []string {
+	var out []string
+	for _, l := range []string(splitStr(s)) {
+		if l != "" {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+func splitStr(s string) []string {
+	result := []string{}
+	cur := ""
+	for _, c := range s {
+		if c == '\n' {
+			result = append(result, cur)
+			cur = ""
+		} else {
+			cur += string(c)
+		}
+	}
+	if cur != "" {
+		result = append(result, cur)
+	}
+	return result
+}


### PR DESCRIPTION
## 🎯 What
This PR introduce `[engine:*]` a new capability in SKA. The engine will instruct SKA what type of update perform on the destination file. 

Default engine is the current behavior with the text based update.
YAML engine instead is very powerful and allow to update with `yaml-merge` mode the rendered blueprint into the destination SKA snippet.

More documentation on the `docs-md/` with a dedicated use case document.

## 🤔 Why
In multiple cases, especially scaffolding initial YAMLs the further updates might be too destructive since the user should be able overtime to change YAML properties.

With YAML merge engine the blueprint will ensure only the managed properties are updated on the destination YAML. Any property added by the user - that is not managed in the blueprint - will be preserved.


